### PR TITLE
Include middleware

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,6 +20,7 @@ INSTALLED_APPS = (
 )
 
 TEMPLATE_DIRS = (
+    'django.template.loaders.app_directories.Loader',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/tests/test_urlmiddleware/middleware.py
+++ b/tests/test_urlmiddleware/middleware.py
@@ -3,17 +3,22 @@
 class NoOpMiddleWare(object):
     pass
 
+
 class NoOpMiddleWare2(object):
     pass
+
 
 class NoOpMiddleWare3(object):
     pass
 
+
 class NoOpMiddleWare4(object):
     pass
 
+
 class NoOpMiddleWare5(object):
     pass
+
 
 class NoOpMiddleWare6(object):
     pass

--- a/tests/test_urlmiddleware/tests.py
+++ b/tests/test_urlmiddleware/tests.py
@@ -77,6 +77,15 @@ class MiddlewareTestCase(TestCase):
 
         self.assertEquals(middleware[0].__class__, NoOpMiddleWare)
 
+    def test_no_middleware_url(self):
+
+        from urlmiddleware import URLMiddleware
+
+        m = URLMiddleware()
+        middleware = m.get_matched_middleware("/no_middleware/")
+
+        self.assertEquals(middleware, [])
+
 
 class MatchingCacheTestCase(TestCase):
 
@@ -328,6 +337,7 @@ class MiddlewareRegexURLResolverTestCase(TestCase):
     def test_type_match(self):
 
         from urlmiddleware.urlresolvers import MiddlewareRegexURLResolver
+        from django.core.exceptions import ImproperlyConfigured
 
         resolver = MiddlewareRegexURLResolver(r'^/', 'test_urlmiddleware.urls_fake')
 
@@ -336,4 +346,32 @@ class MiddlewareRegexURLResolverTestCase(TestCase):
 
         resolver = MiddlewareRegexURLResolver(r'^/', 'test_urlmiddleware.urls_empty')
 
-        self.assertEquals(resolver.url_patterns, ())
+        with self.assertRaises(ImproperlyConfigured):
+            resolver.url_patterns
+
+
+class IncludeMiddleware(TestCase):
+
+    def test_include(self):
+
+        from urlmiddleware.base import MiddlewareResolver404
+        from urlmiddleware.urlresolvers import resolve
+
+        with self.assertRaises(MiddlewareResolver404):
+            print resolve('/include_test/')
+
+    def test_include_views(self):
+
+        from django.core.exceptions import ImproperlyConfigured
+        from urlmiddleware.urlresolvers import resolve
+
+        with self.assertRaises(ImproperlyConfigured):
+            print resolve('/include_views_test/')
+
+    def test_include_get(self):
+
+        c = Client()
+
+        response = c.get('/include_test/')
+
+        self.assertEqual(404, response.status_code)

--- a/tests/test_urlmiddleware/urls.py
+++ b/tests/test_urlmiddleware/urls.py
@@ -1,23 +1,29 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls.defaults import patterns, url, include
+
+from urlmiddleware.conf import murl, mpatterns
 
 from test_urlmiddleware.middleware import NoOpMiddleWare, NoOpMiddleWare2
 
 urlpatterns = patterns('django.views.generic.simple',
     url(r'^$', 'direct_to_template', {'template': 'base.html'}),
     url(r'^accounts/$', 'direct_to_template', {'template': 'base.html'}),
+    url(r'^no_middleware/$', 'direct_to_template', {'template': 'base.html'}),
 )
 
 
-middlewarepatterns = patterns('',
-    url(r'^$', NoOpMiddleWare),
-    url(r'^sub/$', NoOpMiddleWare),
-    url(r'^sub/$', NoOpMiddleWare2),
-    url(r'^dotted/$', 'test_urlmiddleware.middleware.NoOpMiddleWare3'),
+middlewarepatterns = mpatterns('',
+    murl(r'^$', NoOpMiddleWare),
+    murl(r'^sub/$', NoOpMiddleWare),
+    murl(r'^sub/$', NoOpMiddleWare2),
+    murl(r'^dotted/$', 'test_urlmiddleware.middleware.NoOpMiddleWare3'),
     (r'^dotted/$', 'test_urlmiddleware.middleware.NoOpMiddleWare4'),
-    url(r'^dupe/$', 'test_urlmiddleware.middleware.NoOpMiddleWare5'),
+    murl(r'^dupe/$', 'test_urlmiddleware.middleware.NoOpMiddleWare5'),
     (r'^dupe/$', 'test_urlmiddleware.middleware.NoOpMiddleWare5'),
+    murl(r'^include_test/$', include('test_urlmiddleware.urls_include')),
+    (r'^include_test/$', include('test_urlmiddleware.urls_include')),
+    murl(r'^include_views_test/$', include('test_urlmiddleware.urls_empty')),
 )
 
-middlewarepatterns += patterns('test_urlmiddleware.middleware',
-    url(r'^dotted2/$', 'NoOpMiddleWare6'),
+middlewarepatterns += mpatterns('test_urlmiddleware.middleware',
+    murl(r'^dotted2/$', 'NoOpMiddleWare6'),
 )

--- a/tests/test_urlmiddleware/urls.py
+++ b/tests/test_urlmiddleware/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls.defaults import patterns, url, include
 
-from urlmiddleware.conf import murl, mpatterns
+from urlmiddleware.conf import middleware, mpatterns
 
 from test_urlmiddleware.middleware import NoOpMiddleWare, NoOpMiddleWare2
 
@@ -12,18 +12,18 @@ urlpatterns = patterns('django.views.generic.simple',
 
 
 middlewarepatterns = mpatterns('',
-    murl(r'^$', NoOpMiddleWare),
-    murl(r'^sub/$', NoOpMiddleWare),
-    murl(r'^sub/$', NoOpMiddleWare2),
-    murl(r'^dotted/$', 'test_urlmiddleware.middleware.NoOpMiddleWare3'),
+    middleware(r'^$', NoOpMiddleWare),
+    middleware(r'^sub/$', NoOpMiddleWare),
+    middleware(r'^sub/$', NoOpMiddleWare2),
+    middleware(r'^dotted/$', 'test_urlmiddleware.middleware.NoOpMiddleWare3'),
     (r'^dotted/$', 'test_urlmiddleware.middleware.NoOpMiddleWare4'),
-    murl(r'^dupe/$', 'test_urlmiddleware.middleware.NoOpMiddleWare5'),
+    middleware(r'^dupe/$', 'test_urlmiddleware.middleware.NoOpMiddleWare5'),
     (r'^dupe/$', 'test_urlmiddleware.middleware.NoOpMiddleWare5'),
-    murl(r'^include_test/$', include('test_urlmiddleware.urls_include')),
+    middleware(r'^include_test/$', include('test_urlmiddleware.urls_include')),
     (r'^include_test/$', include('test_urlmiddleware.urls_include')),
-    murl(r'^include_views_test/$', include('test_urlmiddleware.urls_empty')),
+    middleware(r'^include_views_test/$', include('test_urlmiddleware.urls_empty')),
 )
 
 middlewarepatterns += mpatterns('test_urlmiddleware.middleware',
-    murl(r'^dotted2/$', 'NoOpMiddleWare6'),
+    middleware(r'^dotted2/$', 'NoOpMiddleWare6'),
 )

--- a/tests/test_urlmiddleware/urls_include.py
+++ b/tests/test_urlmiddleware/urls_include.py
@@ -1,0 +1,4 @@
+from django.conf.urls.defaults import patterns
+
+middlewarepatterns = patterns('',
+)

--- a/urlmiddleware/conf.py
+++ b/urlmiddleware/conf.py
@@ -2,21 +2,21 @@ from django.core.exceptions import ImproperlyConfigured
 
 from urlmiddleware.urlresolvers import MiddlewareRegexURLResolver, MiddlewareRegexURLPattern
 
-__all__ = ['mpatterns', 'murl', ]
+__all__ = ['mpatterns', 'middleware', ]
 
 
 def mpatterns(prefix, *args):
     pattern_list = []
     for t in args:
         if isinstance(t, (list, tuple)):
-            t = murl(prefix=prefix, *t)
+            t = middleware(prefix=prefix, *t)
         elif isinstance(t, MiddlewareRegexURLPattern):
             t.add_prefix(prefix)
         pattern_list.append(t)
     return pattern_list
 
 
-def murl(regex, view, kwargs=None, name=None, prefix=''):
+def middleware(regex, view, kwargs=None, name=None, prefix=''):
     if isinstance(view, (list, tuple)):
         # For include(...) processing.
         urlconf_module, app_name, namespace = view

--- a/urlmiddleware/conf.py
+++ b/urlmiddleware/conf.py
@@ -1,0 +1,30 @@
+from django.core.exceptions import ImproperlyConfigured
+
+from urlmiddleware.urlresolvers import MiddlewareRegexURLResolver, MiddlewareRegexURLPattern
+
+__all__ = ['mpatterns', 'murl', ]
+
+
+def mpatterns(prefix, *args):
+    pattern_list = []
+    for t in args:
+        if isinstance(t, (list, tuple)):
+            t = murl(prefix=prefix, *t)
+        elif isinstance(t, MiddlewareRegexURLPattern):
+            t.add_prefix(prefix)
+        pattern_list.append(t)
+    return pattern_list
+
+
+def murl(regex, view, kwargs=None, name=None, prefix=''):
+    if isinstance(view, (list, tuple)):
+        # For include(...) processing.
+        urlconf_module, app_name, namespace = view
+        return MiddlewareRegexURLResolver(regex, urlconf_module, kwargs, app_name=app_name, namespace=namespace)
+    else:
+        if isinstance(view, basestring):
+            if not view:
+                raise ImproperlyConfigured('Empty URL pattern view name not permitted (for pattern %r)' % regex)
+            if prefix:
+                view = prefix + '.' + view
+        return MiddlewareRegexURLPattern(regex, view, kwargs, name)


### PR DESCRIPTION
Using django's include function currently causes problems when combined with middlewarepatterns as it looks for normal urls, not middleware and adds them.

The current branch highlights the problem but doesn't solve it.
