### PR TITLE
Django 1.9 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,6 @@ setup(
     zip_safe=False,
     setup_requires=[
         'versiontools >= 1.6',
-        'django >= 1.3, <1.9',
+        'django >= 1.3',
     ],
 )

--- a/urlmiddleware/__init__.py
+++ b/urlmiddleware/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
 # following PEP 386, versiontools will pick it up
-__version__ = (0, 2, 2, "final", 0)
+__version__ = (0, 2, 3, "final", 0)
 
 from .middleware import URLMiddleware

--- a/urlmiddleware/middleware.py
+++ b/urlmiddleware/middleware.py
@@ -4,7 +4,7 @@ from django.utils import lru_cache
 from urlmiddleware.base import MiddlewareResolver404
 from urlmiddleware.urlresolvers import resolve
 
-@lru_cache.lru_cache(maxsize=None)
+# @lru_cache.lru_cache(maxsize=None)
 def matched_middleware(path):
     return resolve(path)
 

--- a/urlmiddleware/middleware.py
+++ b/urlmiddleware/middleware.py
@@ -1,20 +1,12 @@
 from django.core.exceptions import ImproperlyConfigured
-# from django.utils.functional import memoize
 from django.utils import lru_cache
 
 from urlmiddleware.base import MiddlewareResolver404
 from urlmiddleware.urlresolvers import resolve
 
-# from collections import OrderedDict
-
-# _match_cache = OrderedDict()
-
-
 @lru_cache.lru_cache(maxsize=None)
 def matched_middleware(path):
     return resolve(path)
-# matched_middleware = memoize(matched_middleware, _match_cache, 1)
-
 
 class URLMiddleware(object):
     """

--- a/urlmiddleware/middleware.py
+++ b/urlmiddleware/middleware.py
@@ -1,11 +1,14 @@
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.datastructures import SortedDict
+# from django.utils.datastructures import SortedDict # Removed since Django1.9
 from django.utils.functional import memoize
 
 from urlmiddleware.base import MiddlewareResolver404
 from urlmiddleware.urlresolvers import resolve
 
-_match_cache = SortedDict()
+from collections import OrderedDict
+
+# _match_cache = SortedDict()
+_match_cache = OrderedDict()
 
 
 def matched_middleware(path):

--- a/urlmiddleware/middleware.py
+++ b/urlmiddleware/middleware.py
@@ -4,7 +4,7 @@ from django.utils import lru_cache
 from urlmiddleware.base import MiddlewareResolver404
 from urlmiddleware.urlresolvers import resolve
 
-# @lru_cache.lru_cache(maxsize=None)
+@lru_cache.lru_cache(maxsize=None)
 def matched_middleware(path):
     return resolve(path)
 

--- a/urlmiddleware/middleware.py
+++ b/urlmiddleware/middleware.py
@@ -1,5 +1,4 @@
 from django.core.exceptions import ImproperlyConfigured
-# from django.utils.datastructures import SortedDict # Removed since Django1.9
 from django.utils.functional import memoize
 
 from urlmiddleware.base import MiddlewareResolver404
@@ -7,7 +6,6 @@ from urlmiddleware.urlresolvers import resolve
 
 from collections import OrderedDict
 
-# _match_cache = SortedDict()
 _match_cache = OrderedDict()
 
 

--- a/urlmiddleware/middleware.py
+++ b/urlmiddleware/middleware.py
@@ -1,17 +1,19 @@
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.functional import memoize
+# from django.utils.functional import memoize
+from django.utils import lru_cache
 
 from urlmiddleware.base import MiddlewareResolver404
 from urlmiddleware.urlresolvers import resolve
 
-from collections import OrderedDict
+# from collections import OrderedDict
 
-_match_cache = OrderedDict()
+# _match_cache = OrderedDict()
 
 
+@lru_cache.lru_cache(maxsize=None)
 def matched_middleware(path):
     return resolve(path)
-matched_middleware = memoize(matched_middleware, _match_cache, 1)
+# matched_middleware = memoize(matched_middleware, _match_cache, 1)
 
 
 class URLMiddleware(object):

--- a/urlmiddleware/urlresolvers.py
+++ b/urlmiddleware/urlresolvers.py
@@ -66,7 +66,7 @@ class MiddlewareRegexURLResolver(RegexURLResolver):
         return list(found)
 
 
-@lru_cache.lru_cache(maxsize=None)
+# @lru_cache.lru_cache(maxsize=None)
 def get_resolver(urlconf):
     if urlconf is None:
         from django.conf import settings

--- a/urlmiddleware/urlresolvers.py
+++ b/urlmiddleware/urlresolvers.py
@@ -66,7 +66,7 @@ class MiddlewareRegexURLResolver(RegexURLResolver):
         return list(found)
 
 
-# @lru_cache.lru_cache(maxsize=None)
+@lru_cache.lru_cache(maxsize=None)
 def get_resolver(urlconf):
     if urlconf is None:
         from django.conf import settings

--- a/urlmiddleware/urlresolvers.py
+++ b/urlmiddleware/urlresolvers.py
@@ -3,7 +3,8 @@ from threading import local
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern, ResolverMatch
 from django.utils.encoding import smart_str
-from django.utils.functional import memoize
+# from django.utils.functional import memoize
+from django.utils import lru_cache
 
 from urlmiddleware.base import MiddlewareResolver404
 from urlmiddleware.util.collections import OrderedSet
@@ -66,12 +67,13 @@ class MiddlewareRegexURLResolver(RegexURLResolver):
         return list(found)
 
 
+@lru_cache.lru_cache(maxsize=None)
 def get_resolver(urlconf):
     if urlconf is None:
         from django.conf import settings
         urlconf = settings.ROOT_URLCONF
     return MiddlewareRegexURLResolver(r'^/', urlconf)
-get_resolver = memoize(get_resolver, _resolver_cache, 1)
+# get_resolver = memoize(get_resolver, _resolver_cache, 1)
 
 
 def resolve(path, urlconf=None):

--- a/urlmiddleware/urlresolvers.py
+++ b/urlmiddleware/urlresolvers.py
@@ -3,7 +3,6 @@ from threading import local
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import RegexURLResolver, RegexURLPattern, ResolverMatch
 from django.utils.encoding import smart_str
-# from django.utils.functional import memoize
 from django.utils import lru_cache
 
 from urlmiddleware.base import MiddlewareResolver404
@@ -73,7 +72,6 @@ def get_resolver(urlconf):
         from django.conf import settings
         urlconf = settings.ROOT_URLCONF
     return MiddlewareRegexURLResolver(r'^/', urlconf)
-# get_resolver = memoize(get_resolver, _resolver_cache, 1)
 
 
 def resolve(path, urlconf=None):


### PR DESCRIPTION
Hi @d0ugal,

I coded an attempt to django 1.9 compatibility. Can you review it ? 
the memoize function was removed in 1.9 and django advise to use lru_cache instead.

Please take a look and let me know ! 
Thx
